### PR TITLE
refactor: fix all clippy warnings

### DIFF
--- a/src/bin/larva-disas/main.rs
+++ b/src/bin/larva-disas/main.rs
@@ -12,13 +12,9 @@ fn process(input_path: &str) {
 
     let d = RvDecoder::new(64);
     let mut p = 0;
-    loop {
-        if let Some((insn, size)) = d.disas(&mem[p..mem.len()]) {
-            println!("{:16x}: {:?}", p, insn);
-            p += size;
-        } else {
-            break;
-        }
+    while let Some((insn, size)) = d.disas(&mem[p..mem.len()]) {
+        println!("{p:16x}: {insn:?}");
+        p += size;
 
         if p == mem.len() {
             break;

--- a/src/bin/larva-test/main.rs
+++ b/src/bin/larva-test/main.rs
@@ -34,9 +34,9 @@ fn main() {
     executor.stack(4096).unwrap();
 
     let block_addr = mem.as_ptr() as u64;
-    let entry_pc = block_addr + 0;
-    println!("code addr = {:016x}", block_addr);
-    println!(" entry pc = {:016x}", entry_pc);
+    let entry_pc = block_addr;
+    println!("code addr = {block_addr:016x}");
+    println!(" entry pc = {entry_pc:016x}");
     let exit_reason = executor.exec(entry_pc);
-    println!("exit_reason = {:?}", exit_reason);
+    println!("exit_reason = {exit_reason:?}");
 }

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -94,7 +94,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u8(&self, gaddr: GuestAddr, val: u8) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u8).write(val) })
+            unsafe { (haddr.as_u64() as *mut u8).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -105,7 +106,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u16(&self, gaddr: GuestAddr, val: u16) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u16).write(val) })
+            unsafe { (haddr.as_u64() as *mut u16).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -116,7 +118,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u32(&self, gaddr: GuestAddr, val: u32) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u32).write(val) })
+            unsafe { (haddr.as_u64() as *mut u32).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -127,7 +130,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u64(&self, gaddr: GuestAddr, val: u64) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u64).write(val) })
+            unsafe { (haddr.as_u64() as *mut u64).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -180,7 +184,7 @@ impl<'a> RvInterpreterExecutor<'a> {
     fn fetch_insn(&self) -> Result<(RvInsn, usize), StopReason> {
         let pc = self.state.get_pc();
         if self.debug {
-            println!("pc = {:016x}", pc);
+            println!("pc = {pc:016x}");
         }
 
         // XXX: this is duplicating code from decoder, ideally decoder will
@@ -203,7 +207,7 @@ impl<'a> RvInterpreterExecutor<'a> {
             Err(e) => return e,
         };
         if self.debug {
-            println!("decoded {}b: {:?}", len, insn);
+            println!("decoded {len}b: {insn:?}");
         }
 
         let res = self.interpret_one(&insn, len);
@@ -511,7 +515,7 @@ impl<'a> RvInterpreterExecutor<'a> {
                     .unwrap_or(StopReason::Next)
             }
             RvInsn::Addiw(a) => {
-                let v = self.gx(a.rs1) as i32 + a.imm as i32;
+                let v = self.gx(a.rs1) as i32 + a.imm;
                 self.sx(a.rd, v as i64 as u64);
                 StopReason::Next
             }
@@ -570,7 +574,7 @@ impl<'a> RvInterpreterExecutor<'a> {
             }
             RvInsn::Mulhsu(a) => {
                 let v1 = self.gx(a.rs1) as i64 as i128;
-                let v2 = self.gx(a.rs1) as u64 as i128;
+                let v2 = self.gx(a.rs1) as i128;
                 let v = (v1 * v2) >> 64;
                 self.sx(a.rd, v as u64);
                 StopReason::Next

--- a/src/exec/interp/syscall.rs
+++ b/src/exec/interp/syscall.rs
@@ -14,8 +14,7 @@ impl<'a> RvInterpreterExecutor<'a> {
 
         if self.debug {
             println!(
-                "syscall: {} ({:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x})",
-                nr, arg0, arg1, arg2, arg3, arg4, arg5
+                "syscall: {nr} ({arg0:#x}, {arg1:#x}, {arg2:#x}, {arg3:#x}, {arg4:#x}, {arg5:#x})"
             );
         }
         match nr {
@@ -25,8 +24,7 @@ impl<'a> RvInterpreterExecutor<'a> {
 
             _ => {
                 println!(
-                    "unimplemented syscall: {} ({:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x})",
-                    nr, arg0, arg1, arg2, arg3, arg4, arg5
+                    "unimplemented syscall: {nr} ({arg0:#x}, {arg1:#x}, {arg2:#x}, {arg3:#x}, {arg4:#x}, {arg5:#x})"
                 );
                 self.state.set_x(10, u64::wrapping_neg(38)); // -ENOSYS
                 StopReason::Next

--- a/src/exec/mem.rs
+++ b/src/exec/mem.rs
@@ -74,10 +74,10 @@ fn get_page_shift(page_size: usize) -> usize {
 }
 
 fn align_to_page(len: usize, page_size: usize, page_shift: usize) -> usize {
-    if len % page_size == 0 {
+    if len.is_multiple_of(page_size) {
         len
     } else {
-        (len >> page_shift + 1) << page_shift
+        (len >> (page_shift + 1)) << page_shift
     }
 }
 
@@ -118,7 +118,7 @@ impl GuestMmu {
     }
 
     pub fn consume_host(&mut self, mem: *const u8, len: usize) -> ::std::io::Result<GuestAddr> {
-        let m = MemBlock::Injected { _p: mem, len: len };
+        let m = MemBlock::Injected { _p: mem, len };
         let addr = mem as u64;
 
         let mut maps = self.maps.write().unwrap();
@@ -128,7 +128,7 @@ impl GuestMmu {
     }
 
     pub fn consume_host_mut(&mut self, mem: *mut u8, len: usize) -> ::std::io::Result<GuestAddr> {
-        let m = MemBlock::InjectedMut { _p: mem, len: len };
+        let m = MemBlock::InjectedMut { _p: mem, len };
         let addr = mem as u64;
 
         let mut maps = self.maps.write().unwrap();

--- a/src/rv/insn.rs
+++ b/src/rv/insn.rs
@@ -205,16 +205,14 @@ impl RvDecoder {
                 let insn = (mem[1] as u16) << 8 | (mem[0] as u16);
                 Some((self.rvc.disas(insn).into(), 2))
             }
+        } else if mem.len() < 4 {
+            None
         } else {
-            if mem.len() < 4 {
-                None
-            } else {
-                let insn = (mem[3] as u32) << 24
-                    | (mem[2] as u32) << 16
-                    | (mem[1] as u32) << 8
-                    | (mem[0] as u32);
-                Some((disas_32bit(insn), 4))
-            }
+            let insn = (mem[3] as u32) << 24
+                | (mem[2] as u32) << 16
+                | (mem[1] as u32) << 8
+                | (mem[0] as u32);
+            Some((disas_32bit(insn), 4))
         }
     }
 


### PR DESCRIPTION
This PR fixes all 15+ clippy warnings to achieve a clean `cargo clippy -- -D warnings` pass.

## Fixes applied

| File | Warning | Fix |
|------|---------|-----|
| mem.rs | precedence | Add parentheses: `len >> (page_shift + 1)` |
| mem.rs | redundant-field-names | `len: len` → `len` |
| mem.rs | manual_is_multiple_of | Use `is_multiple_of()` |
| syscall.rs | uninlined-format-args | Inline format variables |
| interp/mod.rs | unit_arg | Extract `unsafe` write before `Ok(())` |
| interp/mod.rs | uninlined-format-args | Inline format variables |
| interp/mod.rs | unnecessary_cast | Remove redundant casts |
| insn.rs | collapsible_else_if | Flatten nested `if` in `else` block |
| larva-disas/main.rs | while_let_loop | Convert to `while let` loop |
| larva-disas/main.rs | uninlined-format-args | Inline format variables |
| larva-test/main.rs | identity_op | Remove `+ 0` |
| larva-test/main.rs | uninlined-format-args | Inline format variables |

## Verification

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] `cargo build` succeeds

Co-authored-by: Kimi k2.5