### PR TITLE
refactor: fix all clippy warnings (one commit per lint)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,29 @@ The interpreter returns `StopReason` after each instruction:
 - Use `todo!()` for unimplemented cases (mark with issue reference if known)
 - Keep `unsafe` blocks minimal and documented with safety comments
 
+### Large-scale changes
+
+When making large-scale changes (e.g., fixing clippy warnings, refactoring, formatting), **split into logical, atomic commits** rather than one big commit:
+
+- **One logical change per commit** — if the change touches multiple independent aspects, split them
+- **Group by concern** — e.g., one commit per lint type, one commit per module refactor
+- **Avoid mixing** — don't combine formatting fixes with logic changes
+
+Examples:
+```bash
+# Good: fixing multiple clippy warnings
+# Commit 1: fix precedence warnings in mem.rs
+# Commit 2: fix redundant-field-names in mem.rs
+# Commit 3: fix uninlined-format-args across all files
+
+# Good: refactoring
+# Commit 1: extract helper functions in module A
+# Commit 2: extract helper functions in module B
+# Commit 3: update call sites
+```
+
+This makes reviews easier, history more meaningful, and allows selective reverts.
+
 ## Commit message style
 
 Follow Conventional Commits:

--- a/src/bin/larva-disas/main.rs
+++ b/src/bin/larva-disas/main.rs
@@ -12,13 +12,9 @@ fn process(input_path: &str) {
 
     let d = RvDecoder::new(64);
     let mut p = 0;
-    loop {
-        if let Some((insn, size)) = d.disas(&mem[p..mem.len()]) {
-            println!("{:16x}: {:?}", p, insn);
-            p += size;
-        } else {
-            break;
-        }
+    while let Some((insn, size)) = d.disas(&mem[p..mem.len()]) {
+        println!("{p:16x}: {insn:?}");
+        p += size;
 
         if p == mem.len() {
             break;

--- a/src/bin/larva-test/main.rs
+++ b/src/bin/larva-test/main.rs
@@ -34,9 +34,9 @@ fn main() {
     executor.stack(4096).unwrap();
 
     let block_addr = mem.as_ptr() as u64;
-    let entry_pc = block_addr + 0;
-    println!("code addr = {:016x}", block_addr);
-    println!(" entry pc = {:016x}", entry_pc);
+    let entry_pc = block_addr;
+    println!("code addr = {block_addr:016x}");
+    println!(" entry pc = {entry_pc:016x}");
     let exit_reason = executor.exec(entry_pc);
-    println!("exit_reason = {:?}", exit_reason);
+    println!("exit_reason = {exit_reason:?}");
 }

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -515,7 +515,7 @@ impl<'a> RvInterpreterExecutor<'a> {
                     .unwrap_or(StopReason::Next)
             }
             RvInsn::Addiw(a) => {
-                let v = self.gx(a.rs1) as i32 + a.imm as i32;
+                let v = self.gx(a.rs1) as i32 + a.imm;
                 self.sx(a.rd, v as i64 as u64);
                 StopReason::Next
             }
@@ -574,7 +574,7 @@ impl<'a> RvInterpreterExecutor<'a> {
             }
             RvInsn::Mulhsu(a) => {
                 let v1 = self.gx(a.rs1) as i64 as i128;
-                let v2 = self.gx(a.rs1) as u64 as i128;
+                let v2 = self.gx(a.rs1) as i128;
                 let v = (v1 * v2) >> 64;
                 self.sx(a.rd, v as u64);
                 StopReason::Next

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -184,7 +184,7 @@ impl<'a> RvInterpreterExecutor<'a> {
     fn fetch_insn(&self) -> Result<(RvInsn, usize), StopReason> {
         let pc = self.state.get_pc();
         if self.debug {
-            println!("pc = {:016x}", pc);
+            println!("pc = {pc:016x}");
         }
 
         // XXX: this is duplicating code from decoder, ideally decoder will
@@ -207,7 +207,7 @@ impl<'a> RvInterpreterExecutor<'a> {
             Err(e) => return e,
         };
         if self.debug {
-            println!("decoded {}b: {:?}", len, insn);
+            println!("decoded {len}b: {insn:?}");
         }
 
         let res = self.interpret_one(&insn, len);

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -94,7 +94,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u8(&self, gaddr: GuestAddr, val: u8) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u8).write(val) })
+            unsafe { (haddr.as_u64() as *mut u8).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -105,7 +106,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u16(&self, gaddr: GuestAddr, val: u16) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u16).write(val) })
+            unsafe { (haddr.as_u64() as *mut u16).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -116,7 +118,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u32(&self, gaddr: GuestAddr, val: u32) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u32).write(val) })
+            unsafe { (haddr.as_u64() as *mut u32).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,
@@ -127,7 +130,8 @@ impl<'a> RvInterpreterExecutor<'a> {
 
     fn set_u64(&self, gaddr: GuestAddr, val: u64) -> Result<(), StopReason> {
         if let Some(haddr) = self.mmu.g2h(gaddr) {
-            Ok(unsafe { (haddr.as_u64() as *mut u64).write(val) })
+            unsafe { (haddr.as_u64() as *mut u64).write(val) };
+            Ok(())
         } else {
             Err(StopReason::Segv {
                 read: false,

--- a/src/exec/interp/syscall.rs
+++ b/src/exec/interp/syscall.rs
@@ -14,8 +14,7 @@ impl<'a> RvInterpreterExecutor<'a> {
 
         if self.debug {
             println!(
-                "syscall: {} ({:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x})",
-                nr, arg0, arg1, arg2, arg3, arg4, arg5
+                "syscall: {nr} ({arg0:#x}, {arg1:#x}, {arg2:#x}, {arg3:#x}, {arg4:#x}, {arg5:#x})"
             );
         }
         match nr {
@@ -25,8 +24,7 @@ impl<'a> RvInterpreterExecutor<'a> {
 
             _ => {
                 println!(
-                    "unimplemented syscall: {} ({:#x}, {:#x}, {:#x}, {:#x}, {:#x}, {:#x})",
-                    nr, arg0, arg1, arg2, arg3, arg4, arg5
+                    "unimplemented syscall: {nr} ({arg0:#x}, {arg1:#x}, {arg2:#x}, {arg3:#x}, {arg4:#x}, {arg5:#x})"
                 );
                 self.state.set_x(10, u64::wrapping_neg(38)); // -ENOSYS
                 StopReason::Next

--- a/src/exec/mem.rs
+++ b/src/exec/mem.rs
@@ -118,7 +118,7 @@ impl GuestMmu {
     }
 
     pub fn consume_host(&mut self, mem: *const u8, len: usize) -> ::std::io::Result<GuestAddr> {
-        let m = MemBlock::Injected { _p: mem, len: len };
+        let m = MemBlock::Injected { _p: mem, len };
         let addr = mem as u64;
 
         let mut maps = self.maps.write().unwrap();
@@ -128,7 +128,7 @@ impl GuestMmu {
     }
 
     pub fn consume_host_mut(&mut self, mem: *mut u8, len: usize) -> ::std::io::Result<GuestAddr> {
-        let m = MemBlock::InjectedMut { _p: mem, len: len };
+        let m = MemBlock::InjectedMut { _p: mem, len };
         let addr = mem as u64;
 
         let mut maps = self.maps.write().unwrap();

--- a/src/exec/mem.rs
+++ b/src/exec/mem.rs
@@ -74,10 +74,10 @@ fn get_page_shift(page_size: usize) -> usize {
 }
 
 fn align_to_page(len: usize, page_size: usize, page_shift: usize) -> usize {
-    if len % page_size == 0 {
+    if len.is_multiple_of(page_size) {
         len
     } else {
-        (len >> page_shift + 1) << page_shift
+        (len >> (page_shift + 1)) << page_shift
     }
 }
 

--- a/src/rv/insn.rs
+++ b/src/rv/insn.rs
@@ -205,16 +205,14 @@ impl RvDecoder {
                 let insn = (mem[1] as u16) << 8 | (mem[0] as u16);
                 Some((self.rvc.disas(insn).into(), 2))
             }
+        } else if mem.len() < 4 {
+            None
         } else {
-            if mem.len() < 4 {
-                None
-            } else {
-                let insn = (mem[3] as u32) << 24
-                    | (mem[2] as u32) << 16
-                    | (mem[1] as u32) << 8
-                    | (mem[0] as u32);
-                Some((disas_32bit(insn), 4))
-            }
+            let insn = (mem[3] as u32) << 24
+                | (mem[2] as u32) << 16
+                | (mem[1] as u32) << 8
+                | (mem[0] as u32);
+            Some((disas_32bit(insn), 4))
         }
     }
 


### PR DESCRIPTION
This PR fixes all clippy warnings, with each lint type in a separate commit as per project conventions.

## Commits

| Commit | Lint Type | Files |
|--------|-----------|-------|
| `d77bc3a` | precedence, manual_is_multiple_of | mem.rs |
| `84d9bc7` | redundant-field-names | mem.rs |
| `024f8f1` | uninlined-format-args | syscall.rs |
| `7831f8c` | unit_arg | interp/mod.rs |
| `84dab47` | uninlined-format-args | interp/mod.rs |
| `aab8c50` | unnecessary_cast | interp/mod.rs |
| `2fa15b4` | collapsible_else_if | insn.rs |
| `8c8872e` | while_let_loop, uninlined-format-args | larva-disas/main.rs |
| `7bb351e` | identity_op, uninlined-format-args | larva-test/main.rs |
| `c6620d2` | docs: update AGENTS.md | AGENTS.md |

## Verification

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] `cargo build` succeeds

Co-authored-by: Kimi k2.5