### PR TITLE
docs: update TODO and add Markdown style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,30 @@ See README.md for full roadmap. Current focus areas:
 3. **Atomics**: Implement RV32A/RV64A for multi-threaded guests
 4. **Translation**: Begin LoongArch code generation (the core BT engine)
 
+## TODO.md workflow
+
+Use `TODO.md` to coordinate work between agents:
+
+### Before starting work
+1. **Check the Mutex section** — is someone already working on this?
+2. **Claim the task** — open a PR adding yourself to the Mutex table
+
+### Claiming a task (example)
+```markdown
+| Task | Assigned To | PR/Branch | Started |
+|------|-------------|-----------|---------|
+| RV64A atomics | @agent-name | #7 / feat/rv64a | 2026-02-08 |
+```
+
+### When done
+1. Move task from Mutex to Done (or check the box in Current Tasks)
+2. Remove your entry from Mutex
+
+### Rules
+- **One task at a time** per agent in Mutex
+- **Small, focused PRs** — if a task is large, split it into sub-tasks
+- **Don't claim without a PR** — the PR proves you're actually working on it
+
 ## Validation checklist
 
 - [ ] `cargo build` compiles without errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,10 +173,12 @@ See README.md for full roadmap. Current focus areas:
 Use `TODO.md` to coordinate work between agents:
 
 ### Before starting work
+
 1. **Check the Mutex section** — is someone already working on this?
 2. **Claim the task** — open a PR adding yourself to the Mutex table
 
 ### Claiming a task (example)
+
 ```markdown
 | Task | Assigned To | PR/Branch | Started |
 |------|-------------|-----------|---------|
@@ -184,13 +186,50 @@ Use `TODO.md` to coordinate work between agents:
 ```
 
 ### When done
+
 1. Move task from Mutex to Done (or check the box in Current Tasks)
 2. Remove your entry from Mutex
 
 ### Rules
+
 - **One task at a time** per agent in Mutex
 - **Small, focused PRs** — if a task is large, split it into sub-tasks
 - **Don't claim without a PR** — the PR proves you're actually working on it
+
+## Documentation style
+
+When editing Markdown files:
+
+- **Blank line after headings** — always add a blank line after any heading (`#`, `##`, `###`, etc.)
+- **Blank line before code blocks** — always add a blank line before fenced code blocks (```)
+
+Good:
+
+```markdown
+## Section Title
+
+Text here.
+
+### Subsection
+
+More text.
+
+```rust
+fn main() {}
+```
+```
+
+Bad:
+
+```markdown
+## Section Title
+Text here.
+### Subsection
+More text.
+```rust
+fn main() {}
+```
+```
 
 ## Validation checklist
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,8 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 ### High Priority
 
+- [ ] **Add CI workflow** — GitHub Actions for build, test, clippy
+
 - [ ] **Complete RV64A atomic operations** — implement all 22 `todo!()` atomics in `src/exec/interp/mod.rs`
   - `LrW`, `ScW`, all `Amo*W` variants
   - `LrD`, `ScD`, all `Amo*D` variants
@@ -57,7 +59,6 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 ### Low Priority
 
-- [ ] **Add CI workflow** — GitHub Actions for build, test, clippy
 - [ ] **Implement FenceI** — instruction fence for self-modifying code
 - [ ] **Improve error handling** — replace more `unwrap()` with proper errors
 - [ ] **Documentation** — add module-level docs to `src/exec/`

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,15 @@ This file tracks tasks for AI agent collaboration on LARVa. Pick a task, create 
 - **Claim a task**: Open a PR that adds your name/agent ID next to the task
 - **Mark done**: Check the box when PR is merged
 - **Add tasks**: File an issue or PR to add new tasks
+- **Check mutex first**: Look at the **Mutex** section before starting work
+
+## Mutex (Work in Progress)
+
+These tasks are currently being worked on. **Do not start these concurrently** — coordinate with the assigned agent first.
+
+| Task | Assigned To | PR/Branch | Started |
+|------|-------------|-----------|---------|
+| *(none)* | — | — | — |
 
 ## Current Tasks
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,23 +24,27 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 - [ ] **Add CI workflow** — GitHub Actions for build, test, clippy
 
 - [ ] **Complete RV64A atomic operations** — implement all 22 `todo!()` atomics in `src/exec/interp/mod.rs`
+
   - `LrW`, `ScW`, all `Amo*W` variants
   - `LrD`, `ScD`, all `Amo*D` variants
   - See `docs/design.md` for LoongArch correspondence
 
 - [ ] **Complete RVF (float) operations** — implement ~25 `todo!()` float ops
+
   - Arithmetic: `FaddS`, `FsubS`, `FmulS`, `FdivS`, `FsqrtS`
   - Comparisons: `FeqS`, `FltS`, `FleS`, `FclassS`
   - Conversions: `Fcvt*S` variants
   - See `docs/design.md` for missing correspondences
 
 - [ ] **Complete RVD (double) operations** — implement ~25 `todo!()` double ops
+
   - Same structure as RVF
   - `FmaddD`, `FmsubD`, etc.
 
 ### Medium Priority
 
 - [ ] **Expand syscall coverage** — add syscalls for running real programs
+
   - [ ] `read` — needed for stdin
   - [ ] `openat` / `open` — file opening
   - [ ] `mmap` / `munmap` — memory mapping
@@ -49,10 +53,12 @@ These tasks are currently being worked on. **Do not start these concurrently** �
   - Target: run a simple static binary (e.g., `busybox`)
 
 - [ ] **Implement TLS (Thread-Local Storage)** — needed for multi-threaded programs
+
   - Add `tp` register to `RvIsaState`
   - Handle `fs`/`gs` segment references in syscalls
 
 - [ ] **Add proper test runner** — replace hardcoded hello-world with actual tests
+
   - Compile RISC-V test programs with `riscv64-linux-gnu-gcc -static`
   - Run and compare output against QEMU
   - Add to CI
@@ -60,17 +66,21 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 ### Low Priority
 
 - [ ] **Implement FenceI** — instruction fence for self-modifying code
+
 - [ ] **Improve error handling** — replace more `unwrap()` with proper errors
+
 - [ ] **Documentation** — add module-level docs to `src/exec/`
 
 ## Future / Research
 
 - [ ] **Binary translation prototype** — start LoongArch code generation
+
   - Research: CRanelift, LLVM, or handwritten assembly?
   - Start with simple block translation
   - Target: translate `addi` → `addi.d`
 
 - [ ] **System-level emulation** — run a minimal kernel
+
   - Requires implementing privileged mode
   - Guest MMU for virtual memory
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,71 @@
+# TODO
+
+This file tracks tasks for AI agent collaboration on LARVa. Pick a task, create a branch, and submit a PR.
+
+## How to use this file
+
+- **Claim a task**: Open a PR that adds your name/agent ID next to the task
+- **Mark done**: Check the box when PR is merged
+- **Add tasks**: File an issue or PR to add new tasks
+
+## Current Tasks
+
+### High Priority
+
+- [ ] **Complete RV64A atomic operations** — implement all 22 `todo!()` atomics in `src/exec/interp/mod.rs`
+  - `LrW`, `ScW`, all `Amo*W` variants
+  - `LrD`, `ScD`, all `Amo*D` variants
+  - See `docs/design.md` for LoongArch correspondence
+
+- [ ] **Complete RVF (float) operations** — implement ~25 `todo!()` float ops
+  - Arithmetic: `FaddS`, `FsubS`, `FmulS`, `FdivS`, `FsqrtS`
+  - Comparisons: `FeqS`, `FltS`, `FleS`, `FclassS`
+  - Conversions: `Fcvt*S` variants
+  - See `docs/design.md` for missing correspondences
+
+- [ ] **Complete RVD (double) operations** — implement ~25 `todo!()` double ops
+  - Same structure as RVF
+  - `FmaddD`, `FmsubD`, etc.
+
+### Medium Priority
+
+- [ ] **Expand syscall coverage** — add syscalls for running real programs
+  - [ ] `read` — needed for stdin
+  - [ ] `openat` / `open` — file opening
+  - [ ] `mmap` / `munmap` — memory mapping
+  - [ ] `close` — file closing
+  - [ ] `brk` — heap management
+  - Target: run a simple static binary (e.g., `busybox`)
+
+- [ ] **Implement TLS (Thread-Local Storage)** — needed for multi-threaded programs
+  - Add `tp` register to `RvIsaState`
+  - Handle `fs`/`gs` segment references in syscalls
+
+- [ ] **Add proper test runner** — replace hardcoded hello-world with actual tests
+  - Compile RISC-V test programs with `riscv64-linux-gnu-gcc -static`
+  - Run and compare output against QEMU
+  - Add to CI
+
+### Low Priority
+
+- [ ] **Add CI workflow** — GitHub Actions for build, test, clippy
+- [ ] **Implement FenceI** — instruction fence for self-modifying code
+- [ ] **Improve error handling** — replace more `unwrap()` with proper errors
+- [ ] **Documentation** — add module-level docs to `src/exec/`
+
+## Future / Research
+
+- [ ] **Binary translation prototype** — start LoongArch code generation
+  - Research: CRanelift, LLVM, or handwritten assembly?
+  - Start with simple block translation
+  - Target: translate `addi` → `addi.d`
+
+- [ ] **System-level emulation** — run a minimal kernel
+  - Requires implementing privileged mode
+  - Guest MMU for virtual memory
+
+## Done
+
+- [x] AGENTS.md — guide for AI agent collaboration
+- [x] Update deps and Rust 2024 edition
+- [x] Fix all clippy warnings


### PR DESCRIPTION
This PR updates TODO.md priorities and adds Markdown style conventions.

## Commits

| Commit | Change |
|--------|--------|
| 8909800 | Move CI workflow from Low to High Priority |
| a98d19d | Add blank lines after headings in TODO.md |
| 0de444f | Document Markdown style guide in AGENTS.md |

## Style Guide

New documentation style section in AGENTS.md:

- Blank line after headings
- Blank line before code blocks

Co-authored-by: Kimi k2.5