### PR TITLE
docs: sync TODO and add reminder to check TODO.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This document guides AI agents working on LARVa — a proof-of-concept RISC-V to
 
 ## Key expectations
 
+- **Check TODO.md first** — Before starting work, read `TODO.md` to see what's planned and claim tasks via the mutex workflow
 - Keep changes minimal and scoped.
 - One logical change per commit (no unrelated edits in the same commit).
 - Prefer safe, idiomatic Rust; avoid `unsafe` unless absolutely necessary.

--- a/TODO.md
+++ b/TODO.md
@@ -21,12 +21,6 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 ### High Priority
 
-- [ ] **Complete RV64A atomic operations** — implement all 22 `todo!()` atomics in `src/exec/interp/mod.rs`
-
-  - `LrW`, `ScW`, all `Amo*W` variants
-  - `LrD`, `ScD`, all `Amo*D` variants
-  - See `docs/design.md` for LoongArch correspondence
-
 - [ ] **Complete RVF (float) operations** — implement ~25 `todo!()` float ops
 
   - Arithmetic: `FaddS`, `FsubS`, `FmulS`, `FdivS`, `FsqrtS`
@@ -89,3 +83,4 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 - [x] Fix all clippy warnings
 - [x] Add CI workflow — GitHub Actions for build, test, clippy
 - [x] Fix MMU bugs — g2h() and align_to_page() fixes
+- [x] RV64A atomic operations — LR, SC, AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, AMOMIN, AMOMAX, AMOMINU, AMOMAXU (32/64-bit variants)


### PR DESCRIPTION
This PR updates TODO.md to reflect completed work and adds a reminder in AGENTS.md.

## Changes

- Mark RV64A atomic operations as complete (moved to Done)
- Add "Check TODO.md first" to key expectations in AGENTS.md

## Next Up

Ready to work on RVF (float) operations next.

Co-authored-by: Kimi k2.5