### PR TITLE
feat(interp): implement RVF (float) operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This document guides AI agents working on LARVa — a proof-of-concept RISC-V to
 
 ## Key expectations
 
+- **Check TODO.md first** — Before starting work, read `TODO.md` to see what's planned and claim tasks via the mutex workflow
 - Keep changes minimal and scoped.
 - One logical change per commit (no unrelated edits in the same commit).
 - Prefer safe, idiomatic Rust; avoid `unsafe` unless absolutely necessary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,24 @@ Co-authored-by: Kimi k2.5
 - For end-to-end: extend `larva-test` or add new test binaries
 - The `larva-test` binary must output "hello world" — this is the smoke test
 
+### Test requirements for PRs
+
+**`feat` and `fix` commits must include tests.** This means:
+
+- New features: add unit tests demonstrating the feature works
+- Bug fixes: add a test that would have caught the bug
+- Refactors: ensure existing tests still pass
+
+Tests can be simple — the goal is verification, not exhaustive coverage. Example:
+
+```rust
+#[test]
+fn test_new_feature() {
+    let result = my_new_function(42);
+    assert_eq!(result, expected_value);
+}
+```
+
 ### Testing against real RISC-V binaries
 
 Compile test programs with:
@@ -226,6 +244,26 @@ git commit -m "feat(interp): implement AMO operations"
 # Edit TODO.md: remove from Mutex, add to Done
 git commit -m "docs(todo): mark RV64A atomics complete"
 git push
+```
+
+### Mutex dropping as HEAD commit
+
+**Important**: The mutex-dropping commit must be the **last commit (HEAD)** on the branch. This ensures:
+
+1. If the PR needs reverts, the mutex claim is automatically reverted too
+2. Clear separation between implementation and administrative changes
+3. Easy review — the final commit shows task completion
+
+**Wrong** (mutex dropped in middle):
+```
+abc123 docs(todo): drop mutex  ← not HEAD
+def456 feat: implement X
+```
+
+**Right** (mutex dropped as HEAD):
+```
+abc123 feat: implement X
+def456 docs(todo): drop mutex  ← HEAD
 ```
 
 ### Claiming a task (Mutex table format)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ This document guides AI agents working on LARVa — a proof-of-concept RISC-V to
 - **Goal**: Near-native RISC-V (RV64GC) emulation on LoongArch via binary translation
 - **License**: GPL-3.0-or-later
 
+### Platform requirements
+
+- **Host**: x86_64 for development; designed to be architecture-agnostic
+- **Floating-point**: IEEE 754-2008 with nan2008 NaN semantics required
+  - Standard on modern systems (Loongson 3A4000+, x86_64, ARM)
+  - Legacy MIPS may differ in NaN signaling behavior
+
 High-level layout:
 
 - `src/rv/`: RISC-V instruction definitions, decoding, disassembly

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ same name, in the rhythm game *maimai*. Binary translation is hard, running such
 logic in privileged mode is even harder; while I cannot play the *maimai*
 chart at all, I do hope to manage the difficulty *here* somehow!
 
+## Requirements
+
+- **Host architecture**: Currently developed and tested on x86_64; designed to be
+  architecture-agnostic for the interpreter
+- **Floating-point**: IEEE 754-2008 compliant implementation with nan2008 NaN
+  signaling/quiet semantics required (standard on modern systems including
+  Loongson 3A4000+, but legacy MIPS may differ)
+
 ## License
 
 [GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)

--- a/TODO.md
+++ b/TODO.md
@@ -21,12 +21,6 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 ### High Priority
 
-- [ ] **Complete RV64A atomic operations** — implement all 22 `todo!()` atomics in `src/exec/interp/mod.rs`
-
-  - `LrW`, `ScW`, all `Amo*W` variants
-  - `LrD`, `ScD`, all `Amo*D` variants
-  - See `docs/design.md` for LoongArch correspondence
-
 - [ ] **Complete RVF (float) operations** — implement ~25 `todo!()` float ops
 
   - Arithmetic: `FaddS`, `FsubS`, `FmulS`, `FdivS`, `FsqrtS`
@@ -89,3 +83,4 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 - [x] Fix all clippy warnings
 - [x] Add CI workflow — GitHub Actions for build, test, clippy
 - [x] Fix MMU bugs — g2h() and align_to_page() fixes
+- [x] RV64A atomic operations — LR, SC, AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, AMOMIN, AMOMAX, AMOMINU, AMOMAXU (32/64-bit variants)

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 | Task | Assigned To | PR/Branch | Started |
 |------|-------------|-----------|---------|
-| RVF float ops | @openclaw | #12 / feat/rvf-float | 2026-02-08 |
+| *(none)* | — | — | — |
 
 ## Current Tasks
 
@@ -84,3 +84,4 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 - [x] Add CI workflow — GitHub Actions for build, test, clippy
 - [x] Fix MMU bugs — g2h() and align_to_page() fixes
 - [x] RV64A atomic operations — LR, SC, AMOSWAP, AMOADD, AMOXOR, AMOAND, AMOOR, AMOMIN, AMOMAX, AMOMINU, AMOMAXU (32/64-bit variants)
+- [x] RVF float operations — FADD, FSUB, FMUL, FDIV, FSQRT, FMADD, FMSUB, FNMADD, FNMSUB, FSGNJ, FMIN, FMAX, FCVT, FEQ, FLT, FLE, FCLASS

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ These tasks are currently being worked on. **Do not start these concurrently** �
 
 | Task | Assigned To | PR/Branch | Started |
 |------|-------------|-----------|---------|
-| *(none)* | — | — | — |
+| RVF float ops | @openclaw | #12 / feat/rvf-float | 2026-02-08 |
 
 ## Current Tasks
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -132,3 +132,17 @@ LA64 correspondence.
 |`amomaxu_d`|`ammax.du`|
 
 RVF and RVD correspondences: TODO
+
+## Implementation notes
+
+### Floating-point
+
+The interpreter assumes the host provides IEEE 754-2008 compliant floating-point
+with nan2008 NaN signaling/quiet semantics. This is standard on modern systems
+(x86_64, ARM, Loongson 3A4000+) but legacy MIPS implementations may differ.
+
+RISC-V (and LoongArch) use nan2008 semantics where:
+- Quiet NaN has the most significant bit of the mantissa set (0x7FC00000)
+- Signaling NaN has the MSB clear (0x7F800001)
+
+Legacy MIPS used the opposite convention.

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -889,6 +889,10 @@ impl<'a> RvInterpreterExecutor<'a> {
                     .err()
                     .unwrap_or(StopReason::Next)
             }
+            // RVF floating-point operations
+            // Note: These assume the host has a conformant IEEE 754-2008 implementation
+            // with nan2008 NaN signaling/quiet semantics. Legacy MIPS implementations
+            // may behave differently.
             RvInsn::FmaddS(a) => {
                 let rs1 = self.gf32(a.rs1);
                 let rs2 = self.gf32(a.rs2);
@@ -1138,7 +1142,8 @@ mod tests {
         assert_eq!(classify_float(subnormal), 1 << 5); // +subnormal
         assert_eq!(classify_float(-subnormal), 1 << 2); // -subnormal
 
-        // NaN
+        // NaN - assumes nan2008 semantics (Loongson 3A4000+ compatible)
+        // Legacy MIPS implementations may differ in NaN signaling behavior
         assert_eq!(classify_float(f32::NAN), 1 << 9); // quiet NaN (most NaNs are quiet)
     }
 }

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -1114,3 +1114,31 @@ impl<'a> RvInterpreterExecutor<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_float() {
+        // Zero
+        assert_eq!(classify_float(0.0), 1 << 4); // +0
+        assert_eq!(classify_float(-0.0), 1 << 3); // -0
+
+        // Infinity
+        assert_eq!(classify_float(f32::INFINITY), 1 << 7); // +inf
+        assert_eq!(classify_float(f32::NEG_INFINITY), 1 << 0); // -inf
+
+        // Normal numbers
+        assert_eq!(classify_float(1.0), 1 << 6); // +normal
+        assert_eq!(classify_float(-1.0), 1 << 1); // -normal
+
+        // Subnormal
+        let subnormal = f32::from_bits(0x00000001);
+        assert_eq!(classify_float(subnormal), 1 << 5); // +subnormal
+        assert_eq!(classify_float(-subnormal), 1 << 2); // -subnormal
+
+        // NaN
+        assert_eq!(classify_float(f32::NAN), 1 << 9); // quiet NaN (most NaNs are quiet)
+    }
+}

--- a/src/exec/interp/mod.rs
+++ b/src/exec/interp/mod.rs
@@ -26,6 +26,54 @@ fn sext_u32(x: u32) -> u64 {
     x as i32 as i64 as u64
 }
 
+/// Classify a float value according to RISC-V FCLASS format.
+/// Returns a bit mask where bit N is set if the value matches class N.
+fn classify_float(val: f32) -> u64 {
+    let bits = val.to_bits();
+    let sign = bits >> 31;
+    let exp = (bits >> 23) & 0xFF;
+    let mant = bits & 0x7FFFFF;
+
+    if exp == 0 && mant == 0 {
+        // Zero
+        if sign == 0 {
+            1 << 4 // +0
+        } else {
+            1 << 3 // -0
+        }
+    } else if exp == 0 {
+        // Subnormal
+        if sign == 0 {
+            1 << 5 // +subnormal
+        } else {
+            1 << 2 // -subnormal
+        }
+    } else if exp == 0xFF {
+        if mant == 0 {
+            // Infinity
+            if sign == 0 {
+                1 << 7 // +inf
+            } else {
+                1 << 0 // -inf
+            }
+        } else {
+            // NaN
+            if mant & 0x400000 != 0 {
+                1 << 9 // quiet NaN
+            } else {
+                1 << 8 // signaling NaN
+            }
+        }
+    } else {
+        // Normal
+        if sign == 0 {
+            1 << 6 // +normal
+        } else {
+            1 << 1 // -normal
+        }
+    }
+}
+
 impl<'a> RvInterpreterExecutor<'a> {
     pub fn new(xlen: usize, state: &'a mut RvIsaState, mmu: &'a mut GuestMmu) -> Self {
         Self {
@@ -841,40 +889,176 @@ impl<'a> RvInterpreterExecutor<'a> {
                     .err()
                     .unwrap_or(StopReason::Next)
             }
-            RvInsn::FmaddS(_) => todo!(),
-            RvInsn::FmsubS(_) => todo!(),
-            RvInsn::FnmsubS(_) => todo!(),
-            RvInsn::FnmaddS(_) => todo!(),
-            RvInsn::FaddS(_) => todo!(),
-            RvInsn::FsubS(_) => todo!(),
-            RvInsn::FmulS(_) => todo!(),
-            RvInsn::FdivS(_) => todo!(),
-            RvInsn::FsqrtS(_) => todo!(),
-            RvInsn::FsgnjS(_) => todo!(),
-            RvInsn::FsgnjnS(_) => todo!(),
-            RvInsn::FsgnjxS(_) => todo!(),
-            RvInsn::FminS(_) => todo!(),
-            RvInsn::FmaxS(_) => todo!(),
-            RvInsn::FcvtWS(_) => todo!(),
-            RvInsn::FcvtWuS(_) => todo!(),
+            RvInsn::FmaddS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let rs3 = self.gf32(a.rs3);
+                self.sf32(a.rd, rs1.mul_add(rs2, rs3));
+                StopReason::Next
+            }
+            RvInsn::FmsubS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let rs3 = self.gf32(a.rs3);
+                self.sf32(a.rd, rs1.mul_add(rs2, -rs3));
+                StopReason::Next
+            }
+            RvInsn::FnmsubS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let rs3 = self.gf32(a.rs3);
+                self.sf32(a.rd, -(rs1.mul_add(rs2, -rs3)));
+                StopReason::Next
+            }
+            RvInsn::FnmaddS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let rs3 = self.gf32(a.rs3);
+                self.sf32(a.rd, -(rs1.mul_add(rs2, rs3)));
+                StopReason::Next
+            }
+            RvInsn::FaddS(a) => {
+                let v = self.gf32(a.rs1) + self.gf32(a.rs2);
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FsubS(a) => {
+                let v = self.gf32(a.rs1) - self.gf32(a.rs2);
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FmulS(a) => {
+                let v = self.gf32(a.rs1) * self.gf32(a.rs2);
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FdivS(a) => {
+                let v = self.gf32(a.rs1) / self.gf32(a.rs2);
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FsqrtS(a) => {
+                let v = self.gf32(a.rs1).sqrt();
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FsgnjS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let sign = rs2.to_bits() & 0x8000_0000;
+                let val = f32::from_bits((rs1.to_bits() & 0x7FFF_FFFF) | sign);
+                self.sf32(a.rd, val);
+                StopReason::Next
+            }
+            RvInsn::FsgnjnS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let sign = (rs2.to_bits() & 0x8000_0000) ^ 0x8000_0000;
+                let val = f32::from_bits((rs1.to_bits() & 0x7FFF_FFFF) | sign);
+                self.sf32(a.rd, val);
+                StopReason::Next
+            }
+            RvInsn::FsgnjxS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                let sign = (rs1.to_bits() & 0x8000_0000) ^ (rs2.to_bits() & 0x8000_0000);
+                let val = f32::from_bits((rs1.to_bits() & 0x7FFF_FFFF) | sign);
+                self.sf32(a.rd, val);
+                StopReason::Next
+            }
+            RvInsn::FminS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                self.sf32(a.rd, rs1.min(rs2));
+                StopReason::Next
+            }
+            RvInsn::FmaxS(a) => {
+                let rs1 = self.gf32(a.rs1);
+                let rs2 = self.gf32(a.rs2);
+                self.sf32(a.rd, rs1.max(rs2));
+                StopReason::Next
+            }
+            RvInsn::FcvtWS(a) => {
+                let v = self.gf32(a.rs1) as i32 as i64 as u64;
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FcvtWuS(a) => {
+                let v = self.gf32(a.rs1) as u32 as u64;
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
             RvInsn::FmvXW(a) => {
                 self.sx(a.rd, self.gf32(a.rs1) as i32 as i64 as u64);
                 StopReason::Next
             }
-            RvInsn::FeqS(_) => todo!(),
-            RvInsn::FltS(_) => todo!(),
-            RvInsn::FleS(_) => todo!(),
-            RvInsn::FclassS(_) => todo!(),
-            RvInsn::FcvtSW(_) => todo!(),
-            RvInsn::FcvtSWu(_) => todo!(),
+            RvInsn::FeqS(a) => {
+                let v = if self.gf32(a.rs1) == self.gf32(a.rs2) {
+                    1
+                } else {
+                    0
+                };
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FltS(a) => {
+                let v = if self.gf32(a.rs1) < self.gf32(a.rs2) {
+                    1
+                } else {
+                    0
+                };
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FleS(a) => {
+                let v = if self.gf32(a.rs1) <= self.gf32(a.rs2) {
+                    1
+                } else {
+                    0
+                };
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FclassS(a) => {
+                let val = self.gf32(a.rs1);
+                let class = classify_float(val);
+                self.sx(a.rd, class);
+                StopReason::Next
+            }
+            RvInsn::FcvtSW(a) => {
+                let v = self.gx(a.rs1) as i32 as f32;
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FcvtSWu(a) => {
+                let v = self.gx(a.rs1) as u32 as f32;
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
             RvInsn::FmvWX(a) => {
                 self.sf32(a.rd, self.gx(a.rs1) as u32 as f32);
                 StopReason::Next
             }
-            RvInsn::FcvtLS(_) => todo!(),
-            RvInsn::FcvtLuS(_) => todo!(),
-            RvInsn::FcvtSL(_) => todo!(),
-            RvInsn::FcvtSLu(_) => todo!(),
+            RvInsn::FcvtLS(a) => {
+                let v = self.gf32(a.rs1) as i64;
+                self.sx(a.rd, v as u64);
+                StopReason::Next
+            }
+            RvInsn::FcvtLuS(a) => {
+                let v = self.gf32(a.rs1) as u64;
+                self.sx(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FcvtSL(a) => {
+                let v = self.gx(a.rs1) as i64 as f32;
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
+            RvInsn::FcvtSLu(a) => {
+                let v = self.gx(a.rs1) as f32;
+                self.sf32(a.rd, v);
+                StopReason::Next
+            }
             RvInsn::Fld(a) => {
                 let addr = (self.gx(a.rs1) as i64 + a.imm as i64) as u64;
                 match self.get_u64(addr.into()) {


### PR DESCRIPTION
This PR implements all 26 RV32F/RV64F floating-point instructions.

## Implemented Instructions

### Arithmetic (9)
- FaddS, FsubS, FmulS, FdivS, FsqrtS
- FmaddS, FmsubS, FnmsubS, FnmaddS (fused multiply-add)

### Sign Injection (3)
- FsgnjS, FsgnjnS, FsgnjxS

### Min/Max (2)
- FminS, FmaxS

### Conversions (8)
- FcvtWS, FcvtWuS (float to 32-bit int)
- FcvtSW, FcvtSWu (32-bit int to float)
- FcvtLS, FcvtLuS (float to 64-bit int)
- FcvtSL, FcvtSLu (64-bit int to float)

### Comparisons (3)
- FeqS, FltS, FleS

### Classification (1)
- FclassS (with classify_float helper function)

## Implementation Notes

- Uses Rust'[0ms f32 operations directly for arithmetic
- FclassS uses bit manipulation to classify NaN, Inf, Zero, Subnormal, Normal
- Sign injection operations manipulate sign bits directly

## Verification

- [x] cargo build passes
- [x] cargo clippy -- -D warnings clean
- [x] cargo test --lib passes
- [x] cargo run --bin larva-test outputs "hello world"

## Remaining Work

RVD (double) operations still TODO (~26 instructions).

Co-authored-by: Kimi k2.5